### PR TITLE
Upgrade to pymodbus v3.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = ["version", "description"]
 requires-python = ">=3.10"
 keywords = ["sun2000", "modbus", "photovoltaic"]
 dependencies = [
-    "pymodbus==2.5.3",
+    "pymodbus==3.7.2",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus==2.5.3
+pymodbus==3.7.2

--- a/sun2000_modbus/inverter.py
+++ b/sun2000_modbus/inverter.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ModbusIOException, ConnectionException
 
 from . import datatypes
@@ -15,10 +15,10 @@ logger.addHandler(handler)
 
 
 class Sun2000:
-    def __init__(self, host, port=502, timeout=5, wait=2, unit=0): # some models need unit=1
+    def __init__(self, host, port=502, timeout=5, wait=2, slave=1):
         self.wait = wait
-        self.unit = unit
-        self.inverter = ModbusTcpClient(host, port, timeout=timeout)
+        self.slave = slave
+        self.inverter = ModbusTcpClient(host=host, port=port, timeout=timeout)
 
     def connect(self):
         if not self.isConnected():
@@ -51,7 +51,7 @@ class Sun2000:
             raise ValueError('Inverter is not connected')
 
         try:
-            register_value = self.inverter.read_holding_registers(register.value.address, register.value.quantity, unit=self.unit)
+            register_value = self.inverter.read_holding_registers(register.value.address, register.value.quantity, slave=self.slave)
             if type(register_value) == ModbusIOException:
                 logger.error("Inverter unit did not respond")
                 raise register_value
@@ -96,7 +96,7 @@ class Sun2000:
         if end_address != 0:
             quantity = end_address - start_address + 1
         try:
-            register_range_value = self.inverter.read_holding_registers(start_address, quantity, unit=self.unit)
+            register_range_value = self.inverter.read_holding_registers(start_address, quantity, slave=self.slave)
             if type(register_range_value) == ModbusIOException:
                 logger.error("Inverter unit did not respond")
                 raise register_range_value

--- a/tests/test_sun2000_modbus.py
+++ b/tests/test_sun2000_modbus.py
@@ -56,14 +56,14 @@ class TestDataTypes(unittest.TestCase):
 
 class TestSun2000(unittest.TestCase):
     def setUp(self) -> None:
-        self.test_inverter = Sun2000(host='192.168.8.1', port=123, timeout=3, wait=0, unit=1)
+        self.test_inverter = Sun2000(host='192.168.8.1', port=123, timeout=3, wait=0, slave=1)
 
     def test_init(self):
         self.assertEqual(self.test_inverter.inverter.host, '192.168.8.1')
         self.assertEqual(self.test_inverter.inverter.port, 123)
         self.assertEqual(self.test_inverter.inverter.timeout, 3)
         self.assertEqual(self.test_inverter.wait, 0)
-        self.assertEqual(self.test_inverter.unit, 1)
+        self.assertEqual(self.test_inverter.slave, 1)
         self.assertEqual(self.test_inverter.isConnected(), False)
 
     @patch(


### PR DESCRIPTION
Pymodbus introduced some breaking changes in version 3, namely the parameter unit was renamed to slave. The ModbusTcpClient class was moved as well. Finally, slave=0 is a broadcast to all devices and will not work in most cases. I had to use slave=1 instead.